### PR TITLE
Optionally prompt for REPL command. Exposes open terminal function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ vim.keymap.set("n", [your keyamp], function() require('nvim-python-repl').send_b
 vim.keymap.set("n", [your keymap], function() require('nvim-python-repl').toggle_execute() end, { desc = "Automatically execute command in REPL after sent"})
 
 vim.keymap.set("n", [your keymap], function() require('nvim-python-repl').toggle_vertical() end, { desc = "Create REPL in vertical or horizontal split"})
+
+vim.keymap.set("n", [your keymap], function() require('nvim-python-repl').open_repl() end, { desc = "Opens the REPL in a window split"})
 ```
 
 ### Options 
@@ -63,7 +65,7 @@ by default can be changed with `:ReplToggleVertical` or `:lua
 require("nvim-python-repl").toggle_vertical()`. 
 
 
-There is an also an option to specify which spawn command you want to use for a given repl (passed as table). 
+There is an also an option to specify which spawn command you want to use for a given repl (passed as table),as well as an option to prompt from the command that starts the REPL.
 
 Here is the default setup: 
 
@@ -71,6 +73,7 @@ Here is the default setup:
 require("nvim-python-repl").setup({
     execute_on_send=false, 
     vsplit=false,
+    prompt_spawn=false,
     spawn_command={
         python="ipython", 
         scala="sbt console",

--- a/doc/nvim-python-repl.txt
+++ b/doc/nvim-python-repl.txt
@@ -21,6 +21,10 @@ send_buffer_to_repl()
 
     Function to send entire buffer to REPL (will open new REPL if none open). 
 
+                                                                *open_repl()*
+open_repl()
+    Function that opens the REPL according to settings.
+
                                                             *toggle_execute()*
 toggle_execute()
 
@@ -32,6 +36,11 @@ toggle_vertical()
 
     Function that toggles whether the REPL should open on vertical or
     horizontal split. 
+
+                                                            *toggle_prompt()*
+toggle_prompt()
+    Function that toggles whether neovim will prompt for the command that spawns
+    the REPL rather than use the deafult one.
 
 ================================================================================
 vim:tw=78:ts=8:ft=help:norl:

--- a/lua/nvim-python-repl/config.lua
+++ b/lua/nvim-python-repl/config.lua
@@ -1,6 +1,7 @@
 local defaults = {
     execute_on_send = true,
     vsplit = true,
+    prompt_spawn = false,
     spawn_command = {
         python = "ipython",
         scala = "sbt console",

--- a/lua/nvim-python-repl/init.lua
+++ b/lua/nvim-python-repl/init.lua
@@ -45,4 +45,14 @@ function M.toggle_vertical()
     print("vsplit=" .. tostring(not original))
 end
 
+function M.toggle_prompt()
+    local original = config.defaults["prompt_spawn"]
+    config.defaults["prompt_spawn"] = not original
+    print("Spawn prompt=" .. tostring(not original))
+end
+
+function M.open_repl()
+    repl.open_repl(M)
+end
+
 return M

--- a/lua/nvim-python-repl/nvim-python-repl.lua
+++ b/lua/nvim-python-repl/nvim-python-repl.lua
@@ -62,12 +62,16 @@ local term_open = function(filetype, config)
     local win = vim.api.nvim_get_current_win()
     vim.api.nvim_win_set_buf(win, buf)
     local choice = ''
-    if filetype == 'scala' then
-        choice = config.spawn_command.scala
-    elseif filetype == 'python' then
-        choice = config.spawn_command.python
-    elseif filetype == 'lua' then
-        choice = config.spawn_command.lua
+    if config.prompt_spawn then
+        choice = vim.fn.input("REPL spawn command: ")
+    else
+        if filetype == 'scala' then
+            choice = config.spawn_command.scala
+        elseif filetype == 'python' then
+            choice = config.spawn_command.python
+        elseif filetype == 'lua' then
+            choice = config.spawn_command.lua
+        end
     end
     local chan = vim.fn.termopen(choice, {
         on_exit = function()
@@ -168,6 +172,11 @@ M.send_buffer_to_repl = function(config)
     local message = construct_message_from_buffer()
     local concat_message = table.concat(message, "\n")
     send_message(filetype, concat_message, config)
+end
+
+M.open_repl = function(config)
+    local filetype = vim.bo.filetype
+    term_open(filetype, config)
 end
 
 return M

--- a/plugin/nvim-python-repl.vim
+++ b/plugin/nvim-python-repl.vim
@@ -11,7 +11,8 @@ command! SendPySelection           lua require("nvim-python-repl").send_visual_t
 command! SendPyBuffer              lua require("nvim-python-repl").send_buffer_to_repl()
 command! ToggleExecuteOnSend       lua require("nvim-python-repl").toggle_execute()
 command! ReplToggleVertical        lua require("nvim-python-repl").toggle_vertical()
-
+command! ReplTogglePrompt          lua require("nvim-python-repl").toggle_prompt()
+command! ReplOpen                  lua require("nvim-python-repl").open_repl()
 " Remove default mappings
 " nnoremap <silent> <leader>n :SendPyObject<CR>
 " nnoremap <silent> <leader>e :ToggleExecuteOnSend<CR>


### PR DESCRIPTION
Sometimes projects require to pass custom arguments to the REPL as to be able to have the proper environment to run and test the code. This PR adds the functionality to prompt the user for the command that will open the REPL.

A minor addition is to also expose the open_terminal function so the user can manually trigger it.  This could be useful in case one wants to input commands (such as function arguments) into the REPL before sending over code to it.