### PR TITLE
Add tree-sitter requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ is opened from the directory containing `build.sbt`).
 In addition to sending treesitter objects, there is also support for sending a
 selection from visual mode. 
 
+### Requirements
+#### tree-sitter parser
+You will need to install [the tree-sitter parser that corresponds to your desired programming language](https://github.com/tree-sitter). For example, for Python, you will need to execute `:TSInstall python` before `nvim-python-repl` will function properly.
+
 ### Usage 
 
 Can be installed with any plugin manager. For example, in lazy you can use 


### PR DESCRIPTION
From [this issue](https://github.com/geg2102/nvim-python-repl/issues/14#issuecomment-2590740280), some more documentation on installation might be helpful.