### PR TITLE
fix: remove dependency on nvim-treesitter abstraction layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Can be installed with any plugin manager. For example, in lazy you can use
 ...
     {
     "geg2102/nvim-python-repl",
-    dependencies = "nvim-treesitter",
+    -- dependencies = "nvim-treesitter", Not necessary 
     ft = {"python", "lua", "scala"}, 
     config = function()
         require("nvim-python-repl").setup({

--- a/lua/nvim-python-repl/nvim-python-repl.lua
+++ b/lua/nvim-python-repl/nvim-python-repl.lua
@@ -1,4 +1,3 @@
-local ts_utils = require("nvim-treesitter.ts_utils")
 local api = vim.api
 
 M = {}
@@ -22,7 +21,7 @@ local visual_selection_range = function()
 end
 
 local get_statement_definition = function(filetype)
-    local node = ts_utils.get_node_at_cursor()
+    local node = vim.treesitter.get_node()
     if (node:named() == false) then
         error("Node not recognized. Check to ensure treesitter parser is installed.")
     end


### PR DESCRIPTION
This removes dependency on nvim-treesitter and fixes #20 